### PR TITLE
fix: CSPRNG

### DIFF
--- a/src/main/java/io/voucherify/generator/VoucherCodes.java
+++ b/src/main/java/io/voucherify/generator/VoucherCodes.java
@@ -1,10 +1,10 @@
 package io.voucherify.generator;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 public final class VoucherCodes {
 
-    private static final Random RND = new Random(System.currentTimeMillis());
+    private static final SecureRandom RND = new SecureRandom(System.currentTimeMillis());
        
     /**
      * Generates a random code according to given config. 


### PR DESCRIPTION
A clever user with access to enough voucher codes can recover the initial state of a long-running Java process, allowing them to forge codes.  Seed recovery of Knuth's PRNG is a practical attack: https://hal.archives-ouvertes.fr/hal-02700791/document

Since voucher codes may have monetary value, I would recommend applying this relatively trivial patch.